### PR TITLE
Feature: #21 낚시 게임 난이도 조절

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -153,14 +153,6 @@ body{
     flex-direction: column;
     align-items: center;
 }
-#score-display {
-    position: absolute;
-    top: 20px;
-    left: 50%;
-    transform: translateX(-50%);
-    font-weight: bold;
-    font-size: 20px;
-}
 
 /* 물고기 이미지 */
 #modal-fish-container {

--- a/index.html
+++ b/index.html
@@ -33,8 +33,6 @@
         <!-- 낚시 모달 -->
         <div class="modal-overlay" id="modal-overlay">
             <div class="modal-content" id="modal-content">
-                <div id="score-display">점수: 0점</div>
-
                 <div id="modal-fish-container">
                     <img src="#" alt="물고기"/>
                 </div>

--- a/js/submodule/catch.js
+++ b/js/submodule/catch.js
@@ -229,6 +229,8 @@ function updateGaugeColor($gaugeBar, currentPercent, successMin, successMax) {
  * @param $resultBox - 결과 정보를 나타낼 창의 요소 노드
  * @param $resultMessage - 결과 메시지 요소 노드
  * @param $resultScore - 게임 결과를 통해 변경되는 최종 점수
+ * @param successMin - 게임 성공 범위 최소값
+ * @param successMax - 게임 성공 범위 최대값
  * @returns {number} 점수
  */
 function handleFishingResult(currentPercent, $clickBtn, score, $resultBox, $resultMessage, $resultScore, successMin, successMax) {

--- a/js/submodule/catch.js
+++ b/js/submodule/catch.js
@@ -137,15 +137,15 @@ export function updateModalUI(fishNumber, onFinished) {
  */
 function getFishScore(fishNumber) {
   switch (fishNumber) {
-    case 1:
+    case 0:
       return 10; // 물고기1: 작고 쉬움
-    case 2:
+    case 1:
       return 20;
-    case 3:
+    case 2:
       return 30;
-    case 4:
+    case 3:
       return 40;
-    case 5:
+    case 4:
       return 50; // 물고기5: 크고 어려움
     default:
       return 0;  // 예외 처리
@@ -174,6 +174,7 @@ function updateGaugeColor($gaugeBar, currentPercent) {
  * @param score - 반환할 점수
  * @param $resultBox - 결과 정보를 나타낼 창의 요소 노드
  * @param $resultMessage - 결과 메시지 요소 노드
+ * @param $resultScore - 게임 결과를 통해 변경되는 최종 점수
  * @returns {number} 점수
  */
 function handleFishingResult(currentPercent, $clickBtn, score, $resultBox, $resultMessage, $resultScore) {

--- a/js/submodule/catch.js
+++ b/js/submodule/catch.js
@@ -210,6 +210,8 @@ function setLevel(fishNumber) {
  * @description 게이지 색상 업데이트 함수
  * @param $gaugeBar - 색상을 변화시킬 게이지 바 요소 노드
  * @param currentPercent - 현재 낚시대 게이지 %
+ * @param successMin - 게임 성공 범위 최소값
+ * @param successMax - 게임 성공 범위 최대값
  */
 function updateGaugeColor($gaugeBar, currentPercent, successMin, successMax) {
   if (currentPercent > successMax) {

--- a/js/submodule/catch.js
+++ b/js/submodule/catch.js
@@ -22,6 +22,8 @@ export function updateModalUI(fishNumber, onFinished) {
     $resultScore,
     $resultCloseBtn,
     $modalOverlay,
+    $guideLineMin,
+    $guideLineMax,
   } = elements;
 
   // ======== 상태관리 변수 및 상수 ======== //
@@ -90,6 +92,9 @@ export function updateModalUI(fishNumber, onFinished) {
 
   // 낚시 게이지 표현
   $gaugeBar.style.height = `${startPercent}%`;
+  $guideLineMin.style.bottom = `${successMin}%`;
+  $guideLineMax.style.bottom = `${successMax}%`;
+  console.log(successMin);
 
   // 게이지 색상 업데이트 함수
   updateGaugeColor($gaugeBar, curPercent, successMin, successMax);

--- a/js/submodule/catch.js
+++ b/js/submodule/catch.js
@@ -57,7 +57,7 @@ export function updateModalUI(fishNumber, onFinished) {
       decGaugeAmount: 8,
       incGaugeAmount: 5,
       intervalMs: 600,
-      successRange: [78, 85],
+      successRange: [70, 85],
       timeLimit: 5000,
       startPercent: 40,
     }
@@ -91,13 +91,16 @@ export function updateModalUI(fishNumber, onFinished) {
   let resultScore = 0;
 
   // 낚시 게이지 표현
+  $gaugeBar.style.transition = 'none'; // 깜빡임 방지
   $gaugeBar.style.height = `${startPercent}%`;
+  // 게이지 색상 업데이트 함수
+  updateGaugeColor($gaugeBar, curPercent, successMin, successMax);
+  void $gaugeBar.offsetHeight; // 강제 리플로우
+  $gaugeBar.style.transition = ''; // transition 복원
   $guideLineMin.style.bottom = `${successMin}%`;
   $guideLineMax.style.bottom = `${successMax}%`;
   console.log(successMin);
 
-  // 게이지 색상 업데이트 함수
-  updateGaugeColor($gaugeBar, curPercent, successMin, successMax);
   
   // 낚시 게임 버튼 초기화(활성화)
   $clickBtn.disabled = false;

--- a/js/submodule/catch.js
+++ b/js/submodule/catch.js
@@ -15,7 +15,6 @@ export function updateModalUI(fishNumber, onFinished) {
     $gaugeBar,
     $message,
     $clickBtn,
-    $scoreDisplay,
     $modalGameContents,
     $modalWatch,
     $resultBox,
@@ -67,7 +66,7 @@ export function updateModalUI(fishNumber, onFinished) {
   // 지정된 시간이 지난 후 게임 종료
   setTimeout(() => {
     timeOver(decTimerId);
-    resultScore = handleFishingResult(curPercent, $scoreDisplay, $clickBtn, fishingScore, $resultBox, $resultMessage, $resultScore);
+    resultScore = handleFishingResult(curPercent, $clickBtn, fishingScore, $resultBox, $resultMessage, $resultScore);
 
     // 게임 끝났으니 콜백 호출
     if (typeof onFinished === 'function') {
@@ -171,20 +170,18 @@ function updateGaugeColor($gaugeBar, currentPercent) {
 /**
  * @description - 낚시 결과를 처리하는 함수
  * @param currentPercent - 현재 게이지 바 퍼센트
- * @param $display - 점수를 기록하는 요소 노드 (후에 삭제 예정)
  * @param $clickBtn - 게이지 변경 버튼 요소 노드
  * @param score - 반환할 점수
  * @param $resultBox - 결과 정보를 나타낼 창의 요소 노드
  * @param $resultMessage - 결과 메시지 요소 노드
  * @returns {number} 점수
  */
-function handleFishingResult(currentPercent, $display, $clickBtn, score, $resultBox, $resultMessage, $resultScore) {
+function handleFishingResult(currentPercent, $clickBtn, score, $resultBox, $resultMessage, $resultScore) {
 
   $clickBtn.disabled = true;
 
   // 현재 게이지가 70 이상 90 이하 = 성공, 이외 실패
   if (currentPercent >= 70 && currentPercent <= 90) { // 성공
-    $display.textContent = `점수: ${score}점`;
     $resultBox.style.display = 'block';
     $resultMessage.textContent = '🎉 성공!';
     $resultScore.textContent = `획득 점수: ${score}점`

--- a/js/submodule/catch.js
+++ b/js/submodule/catch.js
@@ -60,6 +60,9 @@ export function updateModalUI(fishNumber, onFinished) {
 
   // 게이지 색상 업데이트 함수
   updateGaugeColor($gaugeBar, curPercent);
+  
+  // 낚시 게임 버튼 초기화(활성화)
+  $clickBtn.disabled = false;
 
   // 지정된 시간이 지난 후 게임 종료
   setTimeout(() => {

--- a/js/submodule/dom.js
+++ b/js/submodule/dom.js
@@ -3,7 +3,6 @@ const $modalOverlay = document.getElementById('modal-overlay');
 const $gaugeBar = document.getElementById('gauge-bar');
 const $message = document.getElementById('message');
 const $clickBtn = document.getElementById('modal-click-btn');
-const $scoreDisplay = document.getElementById('score-display');
 const $modalGameContents = document.getElementById('modal-content');
 const $modalWatch = document.getElementById('modal-watch');
 const $sea = document.getElementById('sea-wrapper');
@@ -22,7 +21,6 @@ export default {
     $gaugeBar,
     $message,
     $clickBtn,
-    $scoreDisplay,
     $modalGameContents,
     $modalWatch,
     $sea,

--- a/js/submodule/dom.js
+++ b/js/submodule/dom.js
@@ -15,6 +15,8 @@ const $resultBox = document.getElementById('result-box');
 const $resultMessage = document.getElementById('result-message');
 const $resultScore = document.getElementById('result-score');
 const $resultCloseBtn = document.getElementById('result-close-btn');
+const $guideLineMin = document.querySelector('.guide-line.guide-70');
+const $guideLineMax = document.querySelector('.guide-line.guide-90');
 
 export default {
     $modalOverlay,
@@ -33,4 +35,6 @@ export default {
     $resultMessage,
     $resultScore,
     $resultCloseBtn,
+    $guideLineMin,
+    $guideLineMax,
 };

--- a/js/submodule/fish.js
+++ b/js/submodule/fish.js
@@ -59,6 +59,8 @@ export function start() {
                 $fish.style.backgroundImage = species[4];
                 break;
         }
+
+        return random;
     }
 
     function showFish(){
@@ -91,7 +93,7 @@ export function start() {
 
         $modalOverlay.style.display = 'flex';
 
-        updateModalUI(1, (finalScore) => {
+        updateModalUI(makeFish(), (finalScore) => {
             console.log(`🎯 최종 점수: ${finalScore}`);
             // 여기서 이후 UI 업데이트나 게임 진행 가능
         });


### PR DESCRIPTION
## 개요
- 낚시 게임의 난이도를 조절하는 기능을 제작했습니다.

## 변경 사항
- 물고기에 따라 난이도 다르게 적용
  - 바다 스테이지에서 클릭한 물고기의 정보를 게임에 넘김
  - 물고기 0, 1 : easy, 2, 3: normal, 4: hard로 난이도 참고
  - 난이도를 통해 한 번에 줄어드는 게이지, 게이지의 인터벌, 클릭 시 증가하는 게이지 양, 성공 범위 등을 스크립트를 이용해 UI, UX 조정

## 테스트 방법
- 로컬에서 게임을 진행해 보며, 성공, 실패 결과에 따른 UI 확인

## 관련 이슈
- Resolves #21 

## 추가 설명
- 