### PR TITLE
Bug: #45 바다 스테이지 홈 버튼 데이터 초기화 오류 수정

### DIFF
--- a/js/submodule/fish.js
+++ b/js/submodule/fish.js
@@ -44,6 +44,9 @@ export function start() {
     let hp = 100;
     let currentHp = getComputedStyle($hpBar).height.slice(0, -1);
 
+    // 점수 텍스트 초기화
+    $score.textContent = `${totalScore}`;
+
     showHp(hp);
 
     const seaWidth = $thowitWrap.offsetWidth;
@@ -112,7 +115,7 @@ export function start() {
 
     function writeLog(score) {
         totalScore += score
-        $score.textContent = totalScore;
+        $score.textContent = `${totalScore}`;
     }
 
     function decreaseHp(finalScore, fishingScore){
@@ -191,7 +194,7 @@ export function start() {
 
         totalScore = 0;
 
-        $score.textContent = ` `;
+        $score.textContent = `${totalScore}`;
 
     }
 
@@ -288,7 +291,7 @@ export function start() {
 
         // 메인으로 나가고 게임 초기화
         closeOverModal();
-        initializeGame()
+        initializeGame();
     })
 
     // 홈 버튼 클릭 → 모달 열기
@@ -313,6 +316,9 @@ export function start() {
         clearTimeout(timerId);
         clearInterval(intervalId);
         intervalId = null;
+        
+        // 게임 초기화
+        initializeGame();
     });
 
     // 우클릭 메뉴 막기


### PR DESCRIPTION
## 개요
- 바다 스테이지에서 홈버튼 누르고 메인 화면 들어갔다가 다시 시작하면 점수랑 내구도가 초기화 되지 않는 현상 정상화

## 변경 사항
- 게임을 제일 처음 실행할 때 $score.textContent = `${totalScore}`;를 통해 점수(0점) 가시화
- initializeGame 함수에서 점수 텍스트를 초기화 할 때 $score.textContent = `${totalScore}`;로 점수(0)가 가시화되게 수정
- 바다 스테이지에서 홈버튼을 누르고 예를 눌렀을 때 initializeGame을 사용하여 게임 초기화

## 테스트 방법
- 로컬에서 브라우저를 통해 직접 실행시키며 테스트

## 관련 이슈
- Resolves #45 

## 추가 설명
1. 처음 시작 화면
![image](https://github.com/user-attachments/assets/c27c10dd-44ea-4699-99a9-25d1d8144195)

2. 게임 진행 화면
![image](https://github.com/user-attachments/assets/7a1e6e82-3b15-410f-8557-4d9a01b11495)

3. 메인 화면에 갔다가 다시 시작한 화면
![image](https://github.com/user-attachments/assets/c7f2a0e1-9096-4169-9849-31f7fbed96a6)




