### PR TITLE
Feature: #52 게임 시작 전 카운트다운 연출

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -338,6 +338,26 @@ body{
     background-position: center;
 }
 
+#countdown-text {
+    position: absolute;
+    font-size: 60px;
+    font-weight: bold;
+    color: white;
+    text-shadow: 2px 2px 5px black;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    /*transform-origin: center center;*/
+    z-index: 999;
+    display: flex;
+    /*animation: fadeInOut 1s ease-in-out;*/
+}
+@keyframes fadeInOut {
+    0% { opacity: 0; transform: scale(0.5) translate(-50%, -50%); }
+    30% { opacity: 1; transform: scale(1.2) translate(-50%, -50%); }
+    100% { opacity: 0; transform: scale(1) translate(-50%, -50%); }
+}
+
 /* 물고기 이미지 */
 #modal-fish-container {
     position: absolute;

--- a/index.html
+++ b/index.html
@@ -81,6 +81,8 @@
             <img src="image/fishingLeftClick.png" alt="왼쪽 클릭 유도" id="click-left-guide" class="click-guide" />
             <img src="image/fishingRightClick.png" alt="오른쪽 클릭 유도" id="click-right-guide" class="click-guide" />
             <div class="modal-content" id="modal-content">
+                <div id="countdown-text" class="countdown-text">Ready</div>
+
                 <div id="modal-fish-container">
                     <img src="image/modal_fish01.png" alt="물고기"/>
                 </div>

--- a/js/submodule/dom.js
+++ b/js/submodule/dom.js
@@ -34,6 +34,7 @@ const $confirmNo = document.getElementById('confirm-no');
 const $gameDescriptionPre = document.getElementById('game-description-pre'); // kdh
 const $gameDescriptionNext = document.getElementById('game-description-next'); // kdh
 const $gameDescriptionTextBox = [...document.querySelectorAll('.game-description-text')]; // kdh
+const $countdown = document.getElementById('countdown-text');
 
 export default {
     $modalOverlay,
@@ -71,4 +72,5 @@ export default {
     $gameDescriptionPre,
     $gameDescriptionNext,
     $gameDescriptionTextBox,
+    $countdown,
 };


### PR DESCRIPTION
## 개요
- 게임 시작 전 사용자에게 준비 시간을 주기 위해서 `Ready → Start` 방식의 시작 전 카운트다운 연출 기능을 추가했습니다.

## 변경 사항
- 낚시 모달에 카운트다운 텍스트 html 추가 및 스타일 적용
- 낚시 모달에 게임 시작 카운트다운 로직 추가 및 초기 버튼 비활성화 처리

## 테스트 방법
- 로컬에서 직접 브라우저로 실행하여 테스트

## 관련 이슈
- Resolves #52 

## 추가 설명
1. Ready
![image](https://github.com/user-attachments/assets/e43d2e4b-85b5-464a-91fb-f8c5c093816d)

2. Start 
![image](https://github.com/user-attachments/assets/27291a3d-e65d-453f-907d-65758de4e2b9)


